### PR TITLE
add missing just-extend package to dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "glslify": "^6.0.1",
     "inherits": "^2.0.1",
     "is-integer": "^1.0.6",
+    "just-extend": "1.1.22",
     "mumath": "^3.3.1",
     "negative-index": "^1.0.0",
     "object-assign": "^4.1.0",


### PR DESCRIPTION
as referenced here https://github.com/audio-lab/gl-waveform/blob/9d14379ca60c5e3dd420a0e1f563b7ad4d3f5fe8/src/core.js#L6